### PR TITLE
Grant all permissions on the $OPT/src/ensembl-vep

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -102,5 +102,5 @@ ENV PATH $OPT/src/ensembl-vep:$PATH
 
 # run INSTALL.pl
 WORKDIR $OPT/src/ensembl-vep
-RUN chmod u+x *.pl
+RUN chmod -R a+rwx .
 RUN ./INSTALL.pl -a a -l


### PR DESCRIPTION
Changing permissions on the whole  $OPT/src/ensembl-vep directory tree allows the INSTALL.pl to run as users injected into the Docker container.  

We run docker in an environment where we inject the user's ID into the container at runtime.  This allows containers running on our cluster to access files that are otherwise inaccessible due to rootsquashing.  When `perl INSTALL.pl` is run on the  ensemblorg/ensembl-vep image, it fails out almost instantly with the following error:  

`Checking for installed versions of the Ensembl API...No such file or directory at INSTALL.pl line 692.`

However, if the permissions are changed to a+rwx for the $OPT/src/ensembl-vep directory tree, `INSTALL.pl` works.  This patch merely forces the below command to be run in `docker build` process.  


See below for a demo:  

```
$ docker run --rm --user alanhoyle -ti ensemblorg/ensembl-vep
alanhoyle@4023c784a4d2:/opt/vep/src/ensembl-vep$ perl INSTALL.pl
WARNING: Unable to carry out version check for ensembl-vep

Hello! This installer is configured to install v94 of the Ensembl API for use by the VEP.
It will not affect any existing installations of the Ensembl API that you may have.

It will also download and install cache files from Ensembl's FTP server.

Checking for installed versions of the Ensembl API...No such file or directory at INSTALL.pl line 692.
alanhoyle@4023c784a4d2:/opt/vep/src/ensembl-vep$ su vep -c "chmod -R a+rwx $PWD"
alanhoyle@4023c784a4d2:/opt/vep/src/ensembl-vep$ perl INSTALL.pl

Hello! This installer is configured to install v94 of the Ensembl API for use by the VEP.
It will not affect any existing installations of the Ensembl API that you may have.

It will also download and install cache files from Ensembl's FTP server.

Checking for installed versions of the Ensembl API...done
It looks like you already have v94 of the API installed.
You shouldn't need to install the API

Skip to the next step (n) to install cache files

Do you want to continue installing the API (y/n)? 
```